### PR TITLE
Add prm writer class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ ADD_EXECUTABLE(parameter_gui_exe
   parameter_delegate.cpp
   xml_parameter_reader.cpp
   xml_parameter_writer.cpp
+  prm_parameter_writer.cpp
   ${SOURCE_MOC}
   ${SOURCE_RCC}
   )

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -310,15 +310,15 @@ namespace dealii
           return false;
         };
 
-      if (filename.contains(".xml"))
+      if (filename.endsWith(".xml",Qt::CaseInsensitive))
         {
           XMLParameterWriter writer(tree_widget);                               // create a xml writer
           if (!writer.write_xml_file(&file))                                    // and write the xml file
             return false;
         }
-      else if (filename.contains(".prm"))
+      else if (filename.endsWith(".prm",Qt::CaseInsensitive))
         {
-          PRMParameterWriter  writer(tree_widget);                              // create a prm writer
+          PRMParameterWriter writer(tree_widget);                               // create a prm writer
           if (!writer.write_prm_file(&file))                                    // and write the prm file
             return false;
         }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -20,6 +20,7 @@
 #include "parameter_delegate.h"
 #include "xml_parameter_reader.h"
 #include "xml_parameter_writer.h"
+#include "prm_parameter_writer.h"
 
 
 namespace dealii
@@ -101,9 +102,9 @@ namespace dealii
     bool MainWindow::save_as()
     {
       QString  file_name =							// open a file dialog
-                 QFileDialog::getSaveFileName(this, tr("Save XML Parameter File"),
+                 QFileDialog::getSaveFileName(this, tr("Save Parameter File"),
                                               QDir::currentPath(),
-                                              tr("XML Files (*.xml)"));
+                                              tr("XML Files (*.xml);;PRM Files (*.prm)"));
 
       if (file_name.isEmpty())							// if no file was selected
         return false;								// return false
@@ -309,10 +310,27 @@ namespace dealii
           return false;
         };
 
-      XMLParameterWriter  xml_writer(tree_widget);				// create a xml_writer
+      if (filename.contains(".xml"))
+        {
+          XMLParameterWriter writer(tree_widget);                               // create a xml writer
+          if (!writer.write_xml_file(&file))                                    // and write the xml file
+            return false;
+        }
+      else if (filename.contains(".prm"))
+        {
+          PRMParameterWriter  writer(tree_widget);                              // create a prm writer
+          if (!writer.write_prm_file(&file))                                    // and write the prm file
+            return false;
+        }
+      else
+        {
+          QMessageBox::warning(this, tr("parameterGUI"),
+                                     tr("Unknown output format: %1.")
+                                     .arg(filename));
+          file.remove();
 
-      if (!xml_writer.write_xml_file(&file))					// and read the xml file
-        return false;
+          return false;
+        }
 
       statusBar()->showMessage(tr("File saved"), 2000);				// if we succeed, show a message
       set_current_file(filename);						// and reset the window

--- a/prm_parameter_writer.cpp
+++ b/prm_parameter_writer.cpp
@@ -35,7 +35,7 @@ namespace dealii
 										// loop over the elements
       for (int i = 0; i < tree_widget->topLevelItemCount(); ++i)
         {
-        const QString item_string = write_item(tree_widget->topLevelItem(i),0);
+        const QString item_string = item_to_string(tree_widget->topLevelItem(i),0);
         device->write(item_string.toAscii());
         }
 
@@ -44,8 +44,8 @@ namespace dealii
 
 
 
-    QString PRMParameterWriter::write_item(const QTreeWidgetItem *item,
-                                           const unsigned int indentation_level)
+    QString PRMParameterWriter::item_to_string(const QTreeWidgetItem *item,
+                                               const unsigned int indentation_level)
     {
       QString item_string;
 
@@ -53,7 +53,7 @@ namespace dealii
         {									// we have a parameter
           bool non_default_value;
 
-          if (item->text(5).contains("Double"))
+          if (item->text(5).startsWith("[Double"))
             non_default_value = item->data(1,Qt::DisplayRole).toReal() != item->data(2,Qt::DisplayRole).toReal();
           else
             non_default_value = item->data(1,Qt::DisplayRole).toString() != item->data(2,Qt::DisplayRole).toString();
@@ -70,7 +70,7 @@ namespace dealii
       else
         {
           for (int i = 0; i < item->childCount(); ++i)
-            item_string.push_back(write_item(item->child(i),indentation_level+1));
+            item_string.push_back(item_to_string(item->child(i),indentation_level+1));
 
           if (!item_string.isEmpty())
             {

--- a/prm_parameter_writer.cpp
+++ b/prm_parameter_writer.cpp
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by Rene Gassmoeller
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include <QtGui>
+
+#include "prm_parameter_writer.h"
+
+
+namespace dealii
+{
+  namespace ParameterGui
+  {
+    PRMParameterWriter::PRMParameterWriter(QTreeWidget *tree_widget)
+                      : tree_widget(tree_widget)
+    {
+    }
+
+
+
+    bool PRMParameterWriter::write_prm_file(QIODevice *device)
+    {
+										// loop over the elements
+      for (int i = 0; i < tree_widget->topLevelItemCount(); ++i)
+        {
+        const QString item_string = write_item(tree_widget->topLevelItem(i),0);
+        device->write(item_string.toAscii());
+        }
+
+      return true;
+    }
+
+
+
+    QString PRMParameterWriter::write_item(const QTreeWidgetItem *item,
+                                           const unsigned int indentation_level)
+    {
+      QString item_string;
+
+      if (item->childCount() == 0)						// if the "value"-entry of this item is not empty
+        {									// we have a parameter
+          bool non_default_value;
+
+          if (item->text(5).contains("Double"))
+            non_default_value = item->data(1,Qt::DisplayRole).toReal() != item->data(2,Qt::DisplayRole).toReal();
+          else
+            non_default_value = item->data(1,Qt::DisplayRole).toString() != item->data(2,Qt::DisplayRole).toString();
+
+
+          if (non_default_value)
+            {
+              for (unsigned int i=0; i<indentation_level;++i)
+                item_string.push_back("  ");
+
+              item_string.push_back("set " + item->text(0) + " = " + item->data(1,Qt::EditRole).toString() + "\n");
+            }
+        }
+      else
+        {
+          for (int i = 0; i < item->childCount(); ++i)
+            item_string.push_back(write_item(item->child(i),indentation_level+1));
+
+          if (!item_string.isEmpty())
+            {
+              item_string.push_front("subsection " + item->text(0).toAscii() + "\n");
+              for (unsigned int i=0; i<indentation_level;++i)
+                item_string.push_front("  ");
+
+
+              for (unsigned int i=0; i<indentation_level;++i)
+                item_string.push_back("  ");
+              item_string.push_back("end\n\n");
+            }
+        }
+
+      return item_string;
+    }
+  }
+}

--- a/prm_parameter_writer.h
+++ b/prm_parameter_writer.h
@@ -59,21 +59,21 @@ namespace dealii
 
       private:
         /**
-         * This function writes a given @p item of <tt>tree_widget</tt>
-         * to a file in prm format.
-         * If the @p item is a parameter it is written if its value differs
+         * This function creates a string that corresponds to the data written
+         * to a prm file for a given @p item of <tt>tree_widget</tt>.
+         * If the @p item is a parameter it is only written if its value differs
          * from its default value. If the @p item is a subsection, a start element
          * <code>subsection</code> is written and <tt>write_item</tt> is called
          * recursively to write the next <tt>item</tt>.
-         * If not items in this subsection differ from their default value then
+         * If no items in this subsection differ from their default values then
          * the subsection is not written.
          * @p indentation_level describes the level the current item belongs to.
          * 0 describes a top level item and each subsection increases the level
          * by one.
          *
          */
-        QString write_item (const QTreeWidgetItem *item,
-                            const unsigned int indentation_level);
+        QString item_to_string (const QTreeWidgetItem *item,
+                                const unsigned int indentation_level);
 
         /**
          * A pointer to the QTreeWidget structure

--- a/prm_parameter_writer.h
+++ b/prm_parameter_writer.h
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by Rene Gassmoeller
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#ifndef PRMPARAMETERWRITER_H
+#define PRMPARAMETERWRITER_H
+
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+
+
+namespace dealii
+{
+/*! @addtogroup ParameterGui
+ *@{
+ */
+  namespace ParameterGui
+  {
+/**
+ * The PRMParameterWriter class provides an interface to write parameters
+ * stored in a QTreeWidget to a file in deal.II's PRM format.
+ * This class only writes parameters that deviate from their default values to
+ * improve the readability of the created file.
+ *
+ * @note This class is used in the graphical user interface for the
+ * @ref ParameterHandler class.
+ * It is not compiled into the deal.II libraries and can not be used by
+ * applications using deal.II.
+ *
+ * @ingroup ParameterGui
+ * @author Rene Gassmoeller, 2017
+ */
+    class PRMParameterWriter
+    {
+      public:
+        /**
+         * Constructor.
+         * Parameter values from @p tree_widget will be written.
+         */
+        PRMParameterWriter (QTreeWidget *tree_widget);
+
+        /**
+         * This function writes the parameter values stored in <tt>tree_widget</tt>
+         * to @p device in the PRM format.
+         */
+        bool write_prm_file (QIODevice *device);
+
+      private:
+        /**
+         * This function writes a given @p item of <tt>tree_widget</tt>
+         * to a file in prm format.
+         * If the @p item is a parameter it is written if its value differs
+         * from its default value. If the @p item is a subsection, a start element
+         * <code>subsection</code> is written and <tt>write_item</tt> is called
+         * recursively to write the next <tt>item</tt>.
+         * If not items in this subsection differ from their default value then
+         * the subsection is not written.
+         * @p indentation_level describes the level the current item belongs to.
+         * 0 describes a top level item and each subsection increases the level
+         * by one.
+         *
+         */
+        QString write_item (const QTreeWidgetItem *item,
+                            const unsigned int indentation_level);
+
+        /**
+         * A pointer to the QTreeWidget structure
+         * which stores the parameters.
+         */
+        QTreeWidget * tree_widget;
+    };
+  }
+/**@}*/
+}
+
+
+#endif


### PR DESCRIPTION
This pull request adds the possibility to write a file in deal.II's prm format instead of the xml format. The format is determined by investigating the filename provided by the user in the Save File dialog.