### PR TITLE
Remove tooltip

### DIFF
--- a/xml_parameter_reader.cpp
+++ b/xml_parameter_reader.cpp
@@ -176,13 +176,6 @@ namespace dealii
                 {
                   QString documentation = xml.readElementText();			// store it
                   parent->setText(3, documentation);
-
-                  if (!documentation.isEmpty())						// if there is a documentation,
-                    {
-                      parent->setToolTip(0, "Documentation: " + documentation);		// set Documentation as ToolTip for both columns
-                      parent->setToolTip(1, "Documentation: " + documentation);
-                      parent->setStatusTip(0, "Documentation: " + documentation);	// and as StatusTip for the first column also
-                    };
                 }
               else if (xml.isStartElement() && xml.name() == "pattern")			// if it is <pattern>
                 {
@@ -196,6 +189,7 @@ namespace dealii
                   parent->setText(5, pattern_description);
 											// show the type and default
 											// in the StatusLine
+                  parent->setStatusTip(0, "Type: " + pattern_description + "   Default: " + parent->text(2));
                   parent->setStatusTip(1, "Type: " + pattern_description + "   Default: " + parent->text(2));
 
 						// in order to store values as correct data types,

--- a/xml_parameter_reader.cpp
+++ b/xml_parameter_reader.cpp
@@ -188,7 +188,8 @@ namespace dealii
                   QString pattern_description = xml.readElementText();			// store it as text
                   parent->setText(5, pattern_description);
 											// show the type and default
-											// in the StatusLine
+											// in the StatusLine when
+											// hovering over column 0 or 1
                   parent->setStatusTip(0, "Type: " + pattern_description + "   Default: " + parent->text(2));
                   parent->setStatusTip(1, "Type: " + pattern_description + "   Default: " + parent->text(2));
 


### PR DESCRIPTION
This removes the tooltip and changes the status bar to on mouse-over show the data type and default value for each parameter. The main problem with the tooltip was that for long documentation it had problems with line wraps, and ASPECT has some documentation that covers the whole screen, and leads to a flickering behavior of the tooltip (mouse-over on item -> show tooltip -> tooltip covers screen -> no longer mouse-over -> remove tooltip -> start again).