### PR TITLE
Fix multiple file selection

### DIFF
--- a/browse_lineedit.cpp
+++ b/browse_lineedit.cpp
@@ -37,6 +37,7 @@ namespace dealii
 
       QHBoxLayout *layout = new QHBoxLayout;
 
+      layout->setContentsMargins(1,1,1,1);
       layout->addWidget(line_editor);
       layout->addWidget(browse_button);
       setLayout(layout);
@@ -106,6 +107,15 @@ namespace dealii
               name = QFileDialog::getOpenFileName(this, tr("Open File"),
                                                   QDir::currentPath(),
                                                   tr("All Files (*.*)"));
+              break;
+            };
+
+          case files:
+            {
+              QStringList names = QFileDialog::getOpenFileNames(this, tr("Open Files"),
+                                                  QDir::currentPath(),
+                                                  tr("All Files (*.*)"));
+              name = names.join(",");
               break;
             };
 

--- a/browse_lineedit.h
+++ b/browse_lineedit.h
@@ -54,7 +54,7 @@ namespace dealii
 				      * a <tt>directory</tt> dialog. This can be specified
 				      * in the constructor by setting this flag <tt>BrowseType</tt>.
 				      */
-        enum BrowseType {file = 0, directory = 1};
+        enum BrowseType {file = 0, directory = 1, files = 2};
 				     /**
 				      * Constructor. The type of the browse dialog can be specified
 				      * by the flag <tt>BrowseType</tt>, the default is <tt>file</tt>.

--- a/parameter_delegate.cpp
+++ b/parameter_delegate.cpp
@@ -101,7 +101,8 @@ namespace dealii
         {
           QString pattern_description = index.data(Qt::StatusTipRole).toString();	// load pattern description
 											// stored in the StatusLine
-          QRegExp  rx_string("\\b(Anything|MultipleSelection|List|Map)\\b"),
+          QRegExp  rx_string("\\b(Anything|MultipleSelection|Map)\\b"),
+                   rx_list("\\b(List)\\b"),
                    rx_filename("\\b(FileName)\\b"),	
                    rx_dirname("\\b(DirectoryName)\\b"),	
                    rx_integer("\\b(Integer)\\b"),
@@ -117,6 +118,28 @@ namespace dealii
                       this, SLOT(commit_and_close_editor()));				// to the closer function
 
               return line_editor;
+            }
+          else if (rx_list.indexIn (pattern_description) != -1)                         // if the type is "List"
+            {
+              if (rx_filename.indexIn (pattern_description) != -1)
+                {
+                  BrowseLineEdit * filename_editor =                                        // choose a BrowseLineEditor
+                      new BrowseLineEdit(BrowseLineEdit::files, parent);
+
+                  connect(filename_editor, SIGNAL(editingFinished()),
+                          this, SLOT(commit_and_close_editor()));
+
+                  return filename_editor;
+                }
+              else
+                {
+                  QLineEdit * line_editor = new QLineEdit(parent);                                // choose a LineEditor
+
+                  connect(line_editor, SIGNAL(editingFinished()),                           // and connect editors signal
+                          this, SLOT(commit_and_close_editor()));                           // to the closer function
+
+                  return line_editor;
+                }
             }
           else if (rx_filename.indexIn (pattern_description) != -1)			// if the type is "FileName"
             {
@@ -245,7 +268,8 @@ namespace dealii
 											// stored in the StatusLine
 
 
-          QRegExp  rx_string("\\b(Anything|MultipleSelection|List|Map)\\b"),
+          QRegExp  rx_string("\\b(Anything|MultipleSelection|Map)\\b"),
+                   rx_list("\\b(List)\\b"),
                    rx_filename("\\b(FileName)\\b"),
                    rx_dirname("\\b(DirectoryName)\\b"),
                    rx_selection("\\b(Selection)\\b");
@@ -253,6 +277,20 @@ namespace dealii
           if (rx_string.indexIn (pattern_description) != -1)                          // if the type is "Anything"
             {
               QItemDelegate::setEditorData(editor, index);
+            }
+          else if (rx_list.indexIn (pattern_description) != -1)                   // if the type is "List"
+            {
+              if (rx_filename.indexIn (pattern_description) != -1)
+                {
+                  QString  file_name = index.data(Qt::DisplayRole).toString();
+
+                  BrowseLineEdit *filename_editor = qobject_cast<BrowseLineEdit *>(editor); // set the text of the editor
+                  filename_editor->setText(file_name);
+                }
+              else
+                {
+                  QItemDelegate::setEditorData(editor, index);
+                }
             }
           else if (rx_filename.indexIn (pattern_description) != -1)			// if the type is "FileName"
             {
@@ -304,7 +342,8 @@ namespace dealii
           QString pattern_description = index.data(Qt::StatusTipRole).toString();	// load pattern description
 											// stored in the StatusLine
 
-          QRegExp  rx_string("\\b(Anything|MultipleSelection|List|Map)\\b"),
+          QRegExp  rx_string("\\b(Anything|MultipleSelection|Map)\\b"),
+                   rx_list("\\b(List)\\b"),
                    rx_filename("\\b(FileName)\\b"),
                    rx_dirname("\\b(DirectoryName)\\b"),
                    rx_selection("\\b(Selection)\\b");
@@ -312,6 +351,19 @@ namespace dealii
           if (rx_string.indexIn (pattern_description) != -1)                          // if the type is "Anything"
             {
               QItemDelegate::setModelData(editor, model, index);
+            }
+          else if (rx_list.indexIn (pattern_description) != -1)                   // if the type is "List"
+            {
+              if (rx_filename.indexIn (pattern_description) != -1)
+                {
+                  BrowseLineEdit * filename_editor = qobject_cast<BrowseLineEdit *>(editor);        // set the text from the editor
+                  QString value = filename_editor->text();
+                  model->setData(index, value);
+                }
+              else
+                {
+                  QItemDelegate::setModelData(editor, model, index);
+                }
             }
           else if (rx_filename.indexIn (pattern_description) != -1)				// if the type is "FileName"
             {

--- a/parameter_delegate.cpp
+++ b/parameter_delegate.cpp
@@ -243,11 +243,18 @@ namespace dealii
         {
           QString pattern_description = index.data(Qt::StatusTipRole).toString();	// load pattern description
 											// stored in the StatusLine
-          QRegExp  rx_filename("\\b(FileName)\\b"),
+
+
+          QRegExp  rx_string("\\b(Anything|MultipleSelection|List|Map)\\b"),
+                   rx_filename("\\b(FileName)\\b"),
                    rx_dirname("\\b(DirectoryName)\\b"),
                    rx_selection("\\b(Selection)\\b");
 
-          if (rx_filename.indexIn (pattern_description) != -1)				// if the type is "FileName"
+          if (rx_string.indexIn (pattern_description) != -1)                          // if the type is "Anything"
+            {
+              QItemDelegate::setEditorData(editor, index);
+            }
+          else if (rx_filename.indexIn (pattern_description) != -1)			// if the type is "FileName"
             {
               QString  file_name = index.data(Qt::DisplayRole).toString();
 
@@ -297,11 +304,16 @@ namespace dealii
           QString pattern_description = index.data(Qt::StatusTipRole).toString();	// load pattern description
 											// stored in the StatusLine
 
-          QRegExp  rx_filename("\\b(FileName)\\b"),
+          QRegExp  rx_string("\\b(Anything|MultipleSelection|List|Map)\\b"),
+                   rx_filename("\\b(FileName)\\b"),
                    rx_dirname("\\b(DirectoryName)\\b"),
                    rx_selection("\\b(Selection)\\b");
 
-          if (rx_filename.indexIn (pattern_description) != -1)				// if the type is "FileName"
+          if (rx_string.indexIn (pattern_description) != -1)                          // if the type is "Anything"
+            {
+              QItemDelegate::setModelData(editor, model, index);
+            }
+          else if (rx_filename.indexIn (pattern_description) != -1)				// if the type is "FileName"
             {
               BrowseLineEdit * filename_editor = qobject_cast<BrowseLineEdit *>(editor);	// set the text from the editor
               QString value = filename_editor->text();


### PR DESCRIPTION
This PR fixes a crash that occurs when changing a parameter of type List of Filenames. Currently the logic creates a string input field, but expects the result of a `BrowseLineEdit` Widget. This logic is changed in favor of a `BrowseLineEdit` Widget that is able to select multiple files, and stores them as a list of strings that are separated by commas. In the current form the dialog only allows to select multiple files in a single directory, but of course one can afterwards modify the text field and add files in other directories. I also made the margin of the `BrowseLineEdit` smaller. At least on my machine the text field and browse button tended to be to small to display the content properly.