### PR TITLE
Show non-default values in bold

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -66,6 +66,7 @@ namespace dealii
       setCentralWidget(tree_widget);									// connect: if the tree changes, the window will know
 
       connect(tree_widget, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this, SLOT(set_documentation_text(QTreeWidgetItem *, QTreeWidgetItem *)));         // and connect
+      connect(tree_widget, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this, SLOT(item_changed(QTreeWidgetItem *, int)));         // and connect
       connect(tree_widget, SIGNAL(itemChanged(QTreeWidgetItem*, int)), this, SLOT(tree_was_modified()));
 
       QDockWidget *documentation_widget = new QDockWidget(tr("Parameter documentation:"), this);
@@ -95,6 +96,33 @@ namespace dealii
     {
       documentation_text_widget->clear();
       documentation_text_widget->insertPlainText(selected_item->text(3));
+    }
+
+    void MainWindow::item_changed(QTreeWidgetItem *item,
+                                  int column)
+    {
+      if (column != 1)
+        return;
+
+      bool has_default_value;
+
+      if (item->text(5).startsWith("[Double"))
+        has_default_value = item->data(1,Qt::DisplayRole).toReal() == item->data(2,Qt::DisplayRole).toReal();
+      else
+        has_default_value = item->data(1,Qt::DisplayRole).toString() == item->data(2,Qt::DisplayRole).toString();
+
+      if (has_default_value)
+        {
+          QFont font = item->font(1);
+          font.setWeight(QFont::Normal);
+          item->setFont(1,font);
+        }
+      else
+        {
+          QFont font = item->font(1);
+          font.setWeight(QFont::Bold);
+          item->setFont(1,font);
+        }
     }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -104,6 +104,14 @@ namespace dealii
                                      * tree item should be set to its default value.
                                      */
         void set_to_default();
+
+                                    /**
+                                     * A <tt>slot</tt> that is called when any
+                                     * item value has changed. It updates the font depending
+                                     * on whether the item has a default value or not.
+                                     */
+        void item_changed(QTreeWidgetItem *item,
+                          int column);
       private:
 				     /**
 				      * Show an information dialog, how


### PR DESCRIPTION
This PR marks every non-default value with a bold font. 
Doubles are correctly compared (i.e. 1 == 1.0 == 10e0), but lists of doubles are considered as strings for simplicity ("1, 0.6" != "1.0, 0.6").