### PR TITLE
Add more settings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 QT4_WRAP_CPP(SOURCE_MOC
   browse_lineedit.h
   info_message.h
+  settings_dialog.h
   mainwindow.h
   parameter_delegate.h
   )
@@ -41,6 +42,7 @@ QT4_ADD_RESOURCES(SOURCE_RCC
 ADD_EXECUTABLE(parameter_gui_exe
   browse_lineedit.cpp
   info_message.cpp
+  settings_dialog.cpp
   main.cpp
   mainwindow.cpp
   parameter_delegate.cpp

--- a/dealii_parameter_gui.pro
+++ b/dealii_parameter_gui.pro
@@ -11,15 +11,19 @@ DESTDIR = ../../lib/bin
 # Input
 HEADERS += browse_lineedit.h \
            info_message.h \
+           settings_dialog.h \
            mainwindow.h \
            parameter_delegate.h \
            xml_parameter_reader.h \
-           xml_parameter_writer.h
+           xml_parameter_writer.h \
+           prm_parameter_writer.h
 SOURCES += browse_lineedit.cpp \
            info_message.cpp \
+           settings_dialog.cpp \
            main.cpp \
            mainwindow.cpp \
            parameter_delegate.cpp \
            xml_parameter_reader.cpp \
-           xml_parameter_writer.cpp
+           xml_parameter_writer.cpp \
+           prm_parameter_writer.cpp
 RESOURCES += application.qrc

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -119,8 +119,8 @@ namespace dealii
           font.setWeight(QFont::Normal);
           item->setFont(1,font);
 
-          const bool hide_default_items = gui_settings->value("Settings/hideDefault", false).toBool();
-          if (hide_default_items)
+          const bool hide_items_with_default_value = gui_settings->value("Settings/hideDefault", false).toBool();
+          if (hide_items_with_default_value)
             item->setHidden(true);
         }
       else
@@ -311,7 +311,7 @@ namespace dealii
       if (hide_default_values)
         {
         for (int i = 0; i < tree_widget->topLevelItemCount(); ++i)
-            hide_default_item(tree_widget->topLevelItem(i));
+            hide_item_with_default_value(tree_widget->topLevelItem(i));
         hide_default->setChecked(true);
         }
       else
@@ -328,7 +328,7 @@ namespace dealii
 
 
 
-    bool MainWindow::hide_default_item(QTreeWidgetItem *item)
+    bool MainWindow::hide_item_with_default_value(QTreeWidgetItem *item)
     {
       bool has_default_value = true;
 
@@ -341,9 +341,10 @@ namespace dealii
         }
       else
         {
+          // If this element has children recurse into them and check for default values
           for (int i = 0; i < item->childCount(); ++i)
             {
-              const bool child_has_default_value = hide_default_item(item->child(i));
+              const bool child_has_default_value = hide_item_with_default_value(item->child(i));
               has_default_value = has_default_value & child_has_default_value;
             }
         }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -21,8 +21,11 @@
 #include <QTreeWidget>
 #include <QDialog>
 #include <QSettings>
+#include <QToolBar>
+#include <QToolButton>
 
 #include "info_message.h"
+#include "settings_dialog.h"
 
 
 namespace dealii
@@ -112,6 +115,40 @@ namespace dealii
                                      */
         void item_changed(QTreeWidgetItem *item,
                           int column);
+
+        /**
+         * Show an information dialog, how
+         * parameters can be edited.
+         */
+        void show_settings ();
+
+        /**
+         * Apply the new settings to this window.
+         */
+        void apply_settings ();
+
+        /**
+         * Hide all default items in tree_widget if set in gui_settings.
+         * Otherwise restores all default values.
+         */
+        void update_visible_items();
+
+        /**
+         * Reads the font from gui_settings and applies it.
+         */
+        void update_font();
+
+        /**
+         * Changes whether default items should be displayed in the tree widget
+         * and calls update_visible_items() to apply the changes.
+         */
+        void toggle_visible_default_items();
+
+        /**
+         * Function that displays a font selection dialog, stores the result
+         * in gui_settings, and displays the new font.
+         */
+        void select_font();
       private:
 				     /**
 				      * Show an information dialog, how
@@ -126,6 +163,11 @@ namespace dealii
 				      * This function creates all menus.
 				      */
         void create_menus();
+
+        /**
+         * This function creates the toolbar.
+         */
+        void create_toolbar();
 				     /**
 				      * This function checks, if parameters were changed
 				      * and show a dialog, if changes should be saved.
@@ -146,6 +188,13 @@ namespace dealii
 				      */
         void set_current_file (const QString  &filename);
 
+        /**
+         * Determine if the item and all of its children have the default value,
+         * and hide all default items. Returns true if the item and all of its
+         * children have default values.
+         */
+        bool hide_default_item(QTreeWidgetItem *item);
+
 				     /**
 				      * This is the tree structure in which we store all parameters.
 				      */
@@ -154,6 +203,11 @@ namespace dealii
                                       * This is the documentation text area.
                                       */
         QTextEdit *documentation_text_widget;
+
+        /** A tool button that allows to toggle between showing/hiding parameters
+         * with default values.
+         */
+        QToolButton *hide_default;
 				     /**
 				      * This menu provides all file actions as <tt>open</tt>, <tt>save</tt>, <tt>save as</tt>
 				      * and <tt>exit</tt>
@@ -180,6 +234,10 @@ namespace dealii
 				      * QAction <tt>save as</tt> a file.
 				      */
         QAction * save_as_act;
+                                     /**
+                                      * QAction <tt>save as</tt> a file.
+                                      */
+        QAction * settings_act;
 				     /**
 				      * QAction <tt>exit</tt> the GUI.
 				      */
@@ -205,6 +263,9 @@ namespace dealii
 				      * This dialog shows a short information message after loading a file.
 				      */
         InfoMessage * info_message;
+
+        SettingsDialog * settings_dialog;
+
 				     /**
 				      * An object for storing user settings.
 				      */

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -193,7 +193,7 @@ namespace dealii
          * and hide all default items. Returns true if the item and all of its
          * children have default values.
          */
-        bool hide_default_item(QTreeWidgetItem *item);
+        bool hide_item_with_default_value(QTreeWidgetItem *item);
 
 				     /**
 				      * This is the tree structure in which we store all parameters.

--- a/settings_dialog.cpp
+++ b/settings_dialog.cpp
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by Martin Steigemann and Wolfgang Bangerth
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include <QtGui>
+
+#include "settings_dialog.h"
+
+
+namespace dealii
+{
+  namespace ParameterGui
+  {
+    SettingsDialog::SettingsDialog(QSettings *gui_settings,
+                                   QWidget *parent)
+               : QDialog(parent, 0)
+    {
+      setWindowTitle("Settings");
+
+      settings = gui_settings;
+      loadSettings();
+
+      QFormLayout * grid = new QFormLayout(this);
+
+      // add a choose font button
+      change_font = new QPushButton(this);
+      change_font->setText(QErrorMessage::tr("Change font"));
+      connect(change_font, SIGNAL(clicked()), this, SLOT(selectFont()));
+      grid->addRow("Change Font",change_font);
+
+      // add a checkbox
+      hide_default = new QCheckBox(this);
+      hide_default->setChecked(hide_default_values);
+      connect(hide_default, SIGNAL(stateChanged(int)), this, SLOT(changeHideDefault(int)));
+      grid->addRow("Hide default values",hide_default);
+
+      // add an OK button
+      ok = new QPushButton(this);
+      ok->setText(QErrorMessage::tr("&OK"));
+      connect(ok, SIGNAL(clicked()), this, SLOT(accept()));
+
+      // add a Cancel button
+      cancel = new QPushButton(this);
+      cancel->setText(QErrorMessage::tr("&Cancel"));
+      connect(cancel, SIGNAL(clicked()), this, SLOT(reject()));
+      grid->addRow(ok,cancel);
+
+      connect(this, SIGNAL(accepted()), this, SLOT(writeSettings()));
+    }
+
+
+
+    void SettingsDialog::selectFont()
+    {
+      bool ok;
+      QFont new_font = QFontDialog::getFont(
+                      &ok, selected_font, this);
+      if (ok) {
+          selected_font = new_font;
+      }
+    }
+
+
+
+    void SettingsDialog::changeHideDefault(int state)
+    {
+      hide_default_values = state;
+    }
+
+
+
+    void SettingsDialog::loadSettings()
+    {
+      settings->beginGroup("Settings");
+      hide_default_values = settings->value("hideDefault", false).toBool();
+
+      QString stored_font_string = settings->value("Font", QFont().toString()).toString();
+      selected_font.fromString(stored_font_string);
+      settings->endGroup();
+    }
+
+
+
+    void SettingsDialog::writeSettings()
+    {
+      settings->beginGroup("Settings");
+
+      settings->setValue("hideDefault", hide_default_values);
+      settings->setValue("Font", selected_font.toString());
+
+      settings->endGroup();
+    }
+  }
+}
+

--- a/settings_dialog.h
+++ b/settings_dialog.h
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by Martin Steigemann and Wolfgang Bangerth
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#ifndef SETTINGSDIALOG_H
+#define SETTINGSDIALOG_H
+
+#include <QDialog>
+#include <QSettings>
+#include <QCheckBox>
+
+
+namespace dealii
+{
+/*! @addtogroup ParameterGui
+ *@{
+ */
+  namespace ParameterGui
+  {
+/**
+ * The SettingsDialog class implements a settings dialog for the parameterGUI.
+ * The dialog shows all available settings, and when the user clicks on 'OK'
+ * stores them in the QSettings object handed over in the constructor (which
+ * in turn stores them on disk to allow persistent settings).
+ *
+ * @ingroup ParameterGui
+ * @author Rene Gassmoeller, 2017
+ */
+    class SettingsDialog : public QDialog
+    {
+      Q_OBJECT
+
+      public:
+      /**
+       * Constructor
+       */
+      SettingsDialog (QSettings *settings,
+                      QWidget *parent = 0);
+
+      public slots:
+      /**
+       * Function that displays a font selection dialog and stores the result.
+       */
+      void selectFont();
+
+      /**
+       * Function that stores the checked state of the "Hide default" checkbox.
+       */
+      void changeHideDefault(int state);
+
+      /**
+       * Function that stores the new settings in the settings object
+       * (i.e. on disk).
+       */
+      void writeSettings();
+
+      /**
+       * Function that loads the settings from the settings file.
+       */
+      void loadSettings();
+
+      private:
+      /**
+       * This variable stores if the default values should be hidden. This
+       * might seem duplicative, since it is also stored in <tt>settings</tt>,
+       * but this variable stores the 'current' state of the checkbox,
+       * while <tt>settings</tt> is only updated after clicking OK.
+       */
+      bool hide_default_values;
+
+      /**
+       * The selected font as shown in the Change Font dialog.
+       */
+      QFont selected_font;
+
+      /**
+       * The <tt>Ok</tt> button.
+       */
+      QPushButton * ok;
+
+      /**
+       * The <tt>Cancel</tt> button.
+       */
+      QPushButton * cancel;
+
+      /**
+       * The <tt>Change font</tt> button.
+       */
+      QPushButton * change_font;
+
+      /**
+       * The checkbox<tt>Hide default values</tt>.
+       */
+      QCheckBox * hide_default;
+
+      /**
+       * An object for storing <tt>settings</tt> in a file.
+       */
+      QSettings * settings;
+    };
+  }
+/**@}*/
+}
+
+
+#endif


### PR DESCRIPTION
More specifically add the options to hide default values (to clean up the windows, and only see important options), and to change the window font (e.g. high DPI screens). Both options are available via a settings dialog, and the new toolbar that also allows opening and saving files. I have found the toolbar to be convenient, because it speeds up using the program.