### PR TITLE
Improve settings

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -29,11 +29,8 @@ namespace dealii
   {
     MainWindow::MainWindow(const QString  &filename)
     {
-      // a file for user settings
-      QString  settings_file = QDir::currentPath() + "/settings.ini";
-
       // load settings
-      gui_settings = new QSettings (settings_file, QSettings::IniFormat);
+      gui_settings = new QSettings ("deal.II", "parameterGUI");
 
       // tree for showing XML tags
       tree_widget = new QTreeWidget;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -80,7 +80,10 @@ namespace dealii
       statusBar()->showMessage(tr("Ready, start editing by double-clicking or hitting F2!"));
       setWindowTitle(tr("[*]parameterGUI"));
 
-      showMaximized();
+      gui_settings->beginGroup("MainWindow");
+      resize(gui_settings->value("size", QSize(800, 600)).toSize());
+      move(gui_settings->value("pos", QPoint(0, 0)).toPoint());
+      gui_settings->endGroup();
 
       // if there is a file_name, try to load the file.
       // a valid file has the xml extension, so we require size() > 3
@@ -372,7 +375,14 @@ namespace dealii
       // First check, if we have to save modified content.
       // If not, or the content was saved, accept the event, otherwise ignore it
       if (maybe_save())
-        event->accept();
+        {
+          gui_settings->beginGroup("MainWindow");
+          gui_settings->setValue("size", size());
+          gui_settings->setValue("pos", pos());
+          gui_settings->endGroup();
+
+          event->accept();
+        }
       else
         event->ignore();
     }


### PR DESCRIPTION
I guess soon I can not longer bring up the excuse 'It was that way already' :smile: I am pretty sure I touched all of the lines in the repo by now.

Fixes #13. Qt knows about the default way to store settings on different OS's. On Linux it will create a settings file `~/.config/deal.II/parameterGUI.conf`, on Windows it will use the registry, and on MacOS it uses xml configuration files in a user location. I did not check Windows and Mac, but on Linux it works as expected.
The parameterGUI now also stores its state when exiting, and opens in the same location and same size (e.g. convenient if you want to have it cover half of your desktop).