### PR TITLE
Prepopulate save file dialog

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -180,7 +180,7 @@ namespace dealii
       // open a file dialog
       QString  file_name =
                  QFileDialog::getSaveFileName(this, tr("Save Parameter File"),
-                                              QDir::currentPath(),
+                                              QDir::currentPath() + QDir::separator() + current_file,
                                               tr("XML Files (*.xml);;PRM Files (*.prm)"));
 
       // return if a file was saved


### PR DESCRIPTION
This prepopulates the save file dialog with the currently loaded filename. If no file is loaded at the moment the additional directory separator is ignored.