### PR TITLE
Use global settings instead of settings file for info message

### DIFF
--- a/info_message.cpp
+++ b/info_message.cpp
@@ -23,7 +23,8 @@ namespace dealii
 {
   namespace ParameterGui
   {
-    InfoMessage::InfoMessage(QWidget *parent)
+    InfoMessage::InfoMessage(QSettings *parent_settings,
+                             QWidget *parent)
                : QDialog(parent, 0)
     {
       // this variable stores, if the
@@ -72,10 +73,7 @@ namespace dealii
       grid->setColumnStretch(1, 42);
       grid->setRowStretch(0, 42);
 
-      // load settings from an ini-file
-      QString  settings_file = QDir::currentPath() + "/settings.ini";
-
-      settings = new QSettings (settings_file, QSettings::IniFormat);
+      settings = parent_settings;
 
       // we store settings of this class in the group infoMessage
       settings->beginGroup("infoMessage");

--- a/info_message.h
+++ b/info_message.h
@@ -54,7 +54,8 @@ namespace dealii
       /**
        * Constructor
        */
-      InfoMessage (QWidget *parent = 0);
+      InfoMessage (QSettings *settings,
+                   QWidget *parent = 0);
 
       /**
        * With this function the @p message which will be shown in the

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -286,7 +286,7 @@ namespace dealii
     {
       QString title = "parameterGUI";
 
-      info_message = new InfoMessage(this);
+      info_message = new InfoMessage(gui_settings,this);
 
       info_message->setWindowTitle(title);
       info_message->setInfoMessage(tr("Start Editing by double-clicking on the parameter value or"


### PR DESCRIPTION
This PR fixes an oversight of an earlier PR. The start info message still uses a settings.ini file in the current folder, while all other settings are stored in global settings.